### PR TITLE
add drop function to drop a luhn checksum if it exists in the string

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,12 @@ or ``append`` for convenience
     >>> append('53461861341123')
     '534618613411234'
 
+or ``drop`` for convenience
+
+.. code:: python
+
+    >>> drop('534618613411234')
+    '53461861341123'
 
 .. |pypi| image:: https://img.shields.io/pypi/v/luhn.svg?style=flat-square
    :target: https://pypi.python.org/pypi/luhn

--- a/luhn.py
+++ b/luhn.py
@@ -51,3 +51,5 @@ def drop(string):
     """
     if verify(string):
         return string[:-1]
+    else:
+        return string

--- a/luhn.py
+++ b/luhn.py
@@ -1,4 +1,4 @@
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 
 def checksum(string):
     """
@@ -41,3 +41,13 @@ def append(string):
     '534618613411234'
     """
     return string + str(generate(string))
+
+def drop(string):
+    """
+    Drop Luhn check digit from the end of the provided string.
+
+    >>> append('534618613411234')
+    '53461861341123'
+    """
+    if verify(string):
+        return string[:-1]

--- a/test.py
+++ b/test.py
@@ -29,3 +29,6 @@ def test_generate():
 
 def test_append():
     assert luhn.append('53461861341123') =='534618613411234'
+
+def test_drop():
+    assert luhn.drop('534618613411234') =='53461861341123'

--- a/test.py
+++ b/test.py
@@ -32,3 +32,6 @@ def test_append():
 
 def test_drop():
     assert luhn.drop('534618613411234') =='53461861341123'
+
+def test_drop_none():
+    assert luhn.drop('53461861341123') =='53461861341123'


### PR DESCRIPTION
This way I can just drop it if I no longer need the checksum rather than check if it was there.